### PR TITLE
Fix(rpm): Add systemd feature flag to cargo install

### DIFF
--- a/xwayland-satellite.spec
+++ b/xwayland-satellite.spec
@@ -32,7 +32,7 @@ cargo vendor
 %{cargo_license} > LICENSE.dependencies
 
 %install
-%cargo_install
+%cargo_install -f systemd
 mkdir -p %{buildroot}/usr/lib/systemd/user/
 cp -a resources/xwayland-satellite.service %{buildroot}/usr/lib/systemd/user/
 sed -i "s:/usr/local/bin:%{_bindir}:" %{buildroot}/usr/lib/systemd/user/xwayland-satellite.service


### PR DESCRIPTION
This fixes the issue with systemd integration. Problem  is that cargo install also does a build that overrides the earlier build that was done by cargo build.